### PR TITLE
Habilitar TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ python:
 - 3.6
 install:
 - pip install -r requirements/deploy.txt
+- pip install codecov
+script:
+- coverage erase
+- coverage run web/test_app.py && coverage html
+after_success:
+- codecov
 deploy:
   matrix:
   - provider: heroku

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+- 3.6
+install:
+- pip install -r requirements/deploy.txt
+deploy:
+  matrix:
+  - provider: heroku
+    api_key:
+      secure: NYM1J7x0gboNtqQuq28J+YY8mu07w1k5Ltopn0ZStc70e+bhXiXhyGNPU/zm+6rs98kaMJXHjGTPF/CQHg/px2YjCjubB85XXEgR62eYTF+c0G44bA/aWBYYFnlZaqXDUYefwbP6BRBb8k122ORD7s0WECo72B4GdfTacCv8RP4ZiIZyeC7IhKACFwufqqW6dUha6m3vsk51/Zuvasge0NYcnDPMhNzQZYCyRKK6PsmRddHlOf9JvVgXNH4ddDTcIWrcenTnOcjDyHAOOgSJ/0seOaCQpPpEgrxOYzvG08rkDbNBYWcRm3GssgHNckoEp8AG1h2ru2izhE2Zw6VMiNutiTI26/UB0kpX3wsOma3w1PP7x4TmUZF9+l7NAE1iuZNv0AiWk3YVIsoVhgXOIxnpX7XHukD7T7gy5WqSgkMDFu9f4DDMgeeJAiXBMrQWymdwCN+og5jhbDgv/TCtmVC6hT8H5bC8aQhsTzvdDpsHT30Z6kzZp8b8I653dpzI+y4jXUSpvreaZzdSn63DK0LJuSyLa9ozDtJquZNOKM7ZQuGmcQjFdL8X3BH8v4JfWkcT42is3Yc6/ecbkzPwjWyiZC9NFO2SREOTOu6WHCPG5T+W2N25Z9V67DTuCGqUcrQO+O6NIh78kvAHDIe55kdLYREWlOTTaHa+KPlSPP8=
+    app: selit-web
+    on:
+      python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,15 @@ script:
 - coverage run web/test_app.py && coverage html
 after_success:
 - codecov
+branches:
+  only:
+    - master
+    - develop
 deploy:
-  matrix:
   - provider: heroku
     api_key:
       secure: NYM1J7x0gboNtqQuq28J+YY8mu07w1k5Ltopn0ZStc70e+bhXiXhyGNPU/zm+6rs98kaMJXHjGTPF/CQHg/px2YjCjubB85XXEgR62eYTF+c0G44bA/aWBYYFnlZaqXDUYefwbP6BRBb8k122ORD7s0WECo72B4GdfTacCv8RP4ZiIZyeC7IhKACFwufqqW6dUha6m3vsk51/Zuvasge0NYcnDPMhNzQZYCyRKK6PsmRddHlOf9JvVgXNH4ddDTcIWrcenTnOcjDyHAOOgSJ/0seOaCQpPpEgrxOYzvG08rkDbNBYWcRm3GssgHNckoEp8AG1h2ru2izhE2Zw6VMiNutiTI26/UB0kpX3wsOma3w1PP7x4TmUZF9+l7NAE1iuZNv0AiWk3YVIsoVhgXOIxnpX7XHukD7T7gy5WqSgkMDFu9f4DDMgeeJAiXBMrQWymdwCN+og5jhbDgv/TCtmVC6hT8H5bC8aQhsTzvdDpsHT30Z6kzZp8b8I653dpzI+y4jXUSpvreaZzdSn63DK0LJuSyLa9ozDtJquZNOKM7ZQuGmcQjFdL8X3BH8v4JfWkcT42is3Yc6/ecbkzPwjWyiZC9NFO2SREOTOu6WHCPG5T+W2N25Z9V67DTuCGqUcrQO+O6NIh78kvAHDIe55kdLYREWlOTTaHa+KPlSPP8=
     app: selit-web
     on:
       python: 3.6
+      branch: master

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn --pythonpath web app:app

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Selit! Web
+
+[![Build Status](https://travis-ci.org/unizar-30226-2019-07/Break.svg?branch=master)](https://travis-ci.org/unizar-30226-2019-07/Break)
+[![codecov](https://codecov.io/gh/unizar-30226-2019-07/Break/branch/master/graph/badge.svg)](https://codecov.io/gh/unizar-30226-2019-07/Break)
+
+https://selit-web.herokuapp.com/listings
+
+## Acerca de
 Trabajo de la Universidad de Zaragoza.
 
 Asignatura:
@@ -11,7 +19,7 @@ Autores:
 	Alonso Muñoz
 	Pablo Orduna
 	
-	
+## Instrucciones	
 ***********************************************
 				Instalación
 ***********************************************

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# requirements.txt
+-r requirements/production.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # requirements.txt
--r requirements/production.txt
+-r requirements/deploy.txt

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,0 +1,5 @@
+# requirements/deploy.txt
+-r production.txt
+
+# Heroku deployment
+gunicorn==19.7.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,0 +1,17 @@
+# requirements/production.txt
+
+# Flask and Flask libraries
+## Basic modules
+Flask==1.0.2
+Flask-Bootstrap==3.3.7.1
+
+## Form modules
+Flask-WTF==0.14.2
+
+## Session modules
+Flask-SQLAlchemy==2.3.2
+Flask-Migrate==2.4.0
+Flask-Login==0.4.1
+
+# HTTP requests
+requests==2.21.0

--- a/web/test_app.py
+++ b/web/test_app.py
@@ -1,0 +1,17 @@
+import unittest
+from app import app
+
+
+class HomeViewTest(unittest.TestCase):
+
+    def setUp(self):
+    	self.app = app.test_client()
+    	self.app.testing = True
+
+    def test_home_page(self):
+        home = self.app.get('/')
+        self.assertIn('Inicio', str(home.data))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Se ha configurado TravisCI para:

- [x] Pasar los tests definidos en `web/test_app.py` cada vez que se haga un *push* en `master` o `develop`.
- [x] Comprobar la cobertura de los tests definidos y mostrar el informe en [Codecov](https://codecov.io/gh/unizar-30226-2019-07/Break).
- [x] Desplegar la versión de `master` en [Heroku](https://selit-web.herokuapp.com).
- [x] Modificar el README para mostrar los distintivos (*badges*) de TravisCI y Codecov.